### PR TITLE
Add GitHub Copilot instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# GitHub Copilot Instructions
+
+Follow these repository instructions when working in this project.
+
+## General guidance
+
+- Keep changes focused and consistent with the existing Quarkus + Picocli HackMD CLI architecture.
+- Write new or updated repository instructions, comments, and documentation in English.
+- Avoid machine-specific paths, local-only assumptions, and committed API tokens.
+- Preserve clear boundaries between CLI commands, API client logic, persistence, and utility code.
+- Keep user-facing CLI behavior stable unless the task explicitly changes it.
+
+## Project context
+
+- Main code lives under `src/main/java/io/github/yuokada/quarkus/`.
+- API and persistence models live under `src/main/java/io/github/yuokada/quarkus/model/`.
+- Runtime configuration is defined in `src/main/resources/application.properties`.
+- Build and style rules are managed via Maven Wrapper and `pom.xml`.
+
+## Validation
+
+- Prefer `./mvnw test` for behavior changes.
+- Prefer `./mvnw package` when packaging or CLI startup behavior may be affected.
+- Clearly distinguish between checks you ran and checks you did not run.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ Follow these repository instructions when working in this project.
 
 ## Project context
 
-- Main code lives under `src/main/java/io/github/yuokada/quarkus/`.
+- Main code lives under `src/main/java/io/github/yuokada/quarkus/` and `src/main/java/io/github/yuokada/hackmd/quarkus/`.
 - API and persistence models live under `src/main/java/io/github/yuokada/quarkus/model/`.
 - Runtime configuration is defined in `src/main/resources/application.properties`.
 - Build and style rules are managed via Maven Wrapper and `pom.xml`.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "README.md,.github/workflows/**/*.yml,.github/workflows/**/*.yaml"
+applyTo: "README.md,**/*.md,.github/workflows/**/*.yml,.github/workflows/**/*.yaml"
 ---
 
 When editing documentation or workflow files in this repository:

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "README.md,.github/workflows/**/*.yml,.github/workflows/**/*.yaml"
+---
+
+When editing documentation or workflow files in this repository:
+
+- Keep documentation in English and aligned with the current CLI commands and packaging flow.
+- If environment variable names or command behavior change, update the README in the same change.
+- Avoid documenting local absolute paths or machine-specific setup details as general guidance.

--- a/.github/instructions/java.instructions.md
+++ b/.github/instructions/java.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "src/main/java/**/*.java,src/test/java/**/*.java,pom.xml,src/main/resources/application.properties"
+---
+
+When editing Java or Maven files in this repository:
+
+- Keep command parsing and CLI flow in command classes, not in low-level service or model classes.
+- Keep HackMD API access, authorization handling, Couchbase Lite persistence, and formatting utilities separated by responsibility.
+- Do not introduce real tokens, credentials, or writable local paths into source, tests, or configuration examples.
+- Keep tests close to the affected command, API, or utility behavior.


### PR DESCRIPTION
## Summary
- add repository-wide GitHub Copilot instructions
- add path-specific instruction files for Java, docs, and workflow files
- write the instruction content in English to match the top-level README language

## Testing
- not run (instruction files only)