### PR TITLE
Introduce transport SPI for HackMD service

### DIFF
--- a/src/main/java/io/github/yuokada/hackmd/service/HackMdService.java
+++ b/src/main/java/io/github/yuokada/hackmd/service/HackMdService.java
@@ -1,15 +1,14 @@
 package io.github.yuokada.hackmd.service;
 
-import io.github.yuokada.hackmd.HackMdApi;
 import io.github.yuokada.hackmd.model.CreateNoteRequest;
 import io.github.yuokada.hackmd.model.Note;
 import io.github.yuokada.hackmd.model.NoteDetailResponse;
+import io.github.yuokada.hackmd.transport.HackmdTransport;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 /**
  * A service to interact with the HackMD API and persist note metadata.
@@ -17,7 +16,7 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 @ApplicationScoped
 public class HackMdService {
 
-  @Inject @RestClient HackMdApi hackMdApi;
+  @Inject HackmdTransport hackmdTransport;
 
   /**
    * Lists all notes from the API and synchronizes them with the local database.
@@ -26,13 +25,13 @@ public class HackMdService {
    */
   @Transactional
   public Set<Note> listNotes() {
-    Set<NoteDetailResponse> notes = hackMdApi.getNotes();
+    Set<NoteDetailResponse> notes = hackmdTransport.getNotes();
     return notes.stream().map(NoteDetailResponse::toNote).collect(Collectors.toSet());
   }
 
   public Set<NoteDetailResponse> listNoteDetails() {
     // TODO: Implement pagination if needed
-    return hackMdApi.getNotes();
+    return hackmdTransport.getNotes();
   }
 
   /**
@@ -45,7 +44,7 @@ public class HackMdService {
   @Transactional
   public Note createNote(String title, String content) {
     var request = new CreateNoteRequest(title, content, "owner", "owner");
-    Note newNote = hackMdApi.createNote(request);
+    Note newNote = hackmdTransport.createNote(request);
     return newNote;
   }
 
@@ -57,7 +56,7 @@ public class HackMdService {
    */
   @Transactional
   public NoteDetailResponse getNote(String noteId) {
-    NoteDetailResponse note = hackMdApi.getNote(noteId);
+    NoteDetailResponse note = hackmdTransport.getNote(noteId);
     return note;
   }
 }

--- a/src/main/java/io/github/yuokada/hackmd/transport/HackmdTransport.java
+++ b/src/main/java/io/github/yuokada/hackmd/transport/HackmdTransport.java
@@ -1,0 +1,16 @@
+package io.github.yuokada.hackmd.transport;
+
+import io.github.yuokada.hackmd.model.CreateNoteRequest;
+import io.github.yuokada.hackmd.model.Note;
+import io.github.yuokada.hackmd.model.NoteDetailResponse;
+import java.util.Set;
+
+/** Transport abstraction for HackMD API operations used by the service layer. */
+public interface HackmdTransport {
+
+  Set<NoteDetailResponse> getNotes();
+
+  Note createNote(CreateNoteRequest request);
+
+  NoteDetailResponse getNote(String noteId);
+}

--- a/src/main/java/io/github/yuokada/hackmd/transport/MicroProfileHackmdTransport.java
+++ b/src/main/java/io/github/yuokada/hackmd/transport/MicroProfileHackmdTransport.java
@@ -1,0 +1,32 @@
+package io.github.yuokada.hackmd.transport;
+
+import io.github.yuokada.hackmd.HackMdApi;
+import io.github.yuokada.hackmd.model.CreateNoteRequest;
+import io.github.yuokada.hackmd.model.Note;
+import io.github.yuokada.hackmd.model.NoteDetailResponse;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Set;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+/** MicroProfile REST Client based transport implementation. */
+@ApplicationScoped
+public class MicroProfileHackmdTransport implements HackmdTransport {
+
+  @Inject @RestClient HackMdApi hackMdApi;
+
+  @Override
+  public Set<NoteDetailResponse> getNotes() {
+    return hackMdApi.getNotes();
+  }
+
+  @Override
+  public Note createNote(CreateNoteRequest request) {
+    return hackMdApi.createNote(request);
+  }
+
+  @Override
+  public NoteDetailResponse getNote(String noteId) {
+    return hackMdApi.getNote(noteId);
+  }
+}

--- a/src/test/java/io/github/yuokada/hackmd/service/HackMdServiceTest.java
+++ b/src/test/java/io/github/yuokada/hackmd/service/HackMdServiceTest.java
@@ -1,0 +1,59 @@
+package io.github.yuokada.hackmd.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.yuokada.hackmd.model.Note;
+import io.github.yuokada.hackmd.model.NoteDetailResponse;
+import io.github.yuokada.hackmd.transport.HackmdTransport;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class HackMdServiceTest {
+
+  private HackMdService service;
+  private HackmdTransport transport;
+
+  @BeforeEach
+  void setUp() {
+    service = new HackMdService();
+    transport = Mockito.mock(HackmdTransport.class);
+    service.hackmdTransport = transport;
+  }
+
+  @Test
+  void listNotesDelegatesToTransportAndConvertsToNote() {
+    NoteDetailResponse detail = createNote("note-id", "title");
+    when(transport.getNotes()).thenReturn(Set.of(detail));
+
+    Set<Note> notes = service.listNotes();
+
+    verify(transport).getNotes();
+    assertEquals(1, notes.size());
+    assertEquals("note-id", notes.iterator().next().id());
+  }
+
+  @Test
+  void getNoteDelegatesToTransport() {
+    NoteDetailResponse detail = createNote("note-id", "title");
+    when(transport.getNote("note-id")).thenReturn(detail);
+
+    NoteDetailResponse actual = service.getNote("note-id");
+
+    verify(transport).getNote("note-id");
+    assertSame(detail, actual);
+  }
+
+  private static NoteDetailResponse createNote(String id, String title) {
+    return new NoteDetailResponse(
+        id, title, List.of(),
+        null, null, null, null, null,
+        null, null, "short-" + id, null,
+        null, null, null, null, null, null);
+  }
+}


### PR DESCRIPTION
## Summary
- add `HackmdTransport` abstraction for service-layer API operations
- add `MicroProfileHackmdTransport` implementation backed by `HackMdApi`
- refactor `HackMdService` to depend on transport abstraction
- add `HackMdServiceTest` to validate delegation and conversion

## Verification
- `mvn -q -Dtest=HackMdServiceTest,AuthorizationFilterTest test`

Closes #34